### PR TITLE
docker compose mysql

### DIFF
--- a/mysql/docker-compose.yaml
+++ b/mysql/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3.3'
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'carangobom'
+      # So you don't have to use root, but you can if you like
+      MYSQL_USER: 'user'
+      # You can use whatever password you like
+      MYSQL_PASSWORD: ''
+      # Password for root access
+      MYSQL_ROOT_PASSWORD: ''
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
+      MYSQL_ROOT_HOST: '%'
+    ports:
+      # <Port exposed> : < MySQL Port running inside container>
+      - '3306:3306'
+    expose:
+      # Opens port 3306 on the container
+      - '3306'
+      # Where our data will be persisted
+    volumes:
+      - my-db:/var/lib/mysql
+# Names our volume
+volumes:
+  my-db:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,6 @@ spring.jpa.show-sql = true
 spring.jackson.serialization.fail-on-empty-beans=false
 
 # JWT CONFIGS
-jwt.secret = segredo-secretíssimo
+jwt.secret = segredo-secretï¿½ssimo
 # 7 dias
 jwt.expiration = 604800000


### PR DESCRIPTION
Arquivo docker-compose de um service mysql para simplificar a execução do projeto.

Neste caso não é necessário instalar o mysql na máquina, só executar na pasta mysql:

```bash
docker-compose up
```